### PR TITLE
keep sorted elements separate

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -12,15 +12,15 @@ function sortResults() {
   }).sort((a, b) => b.reviewsCount - a.reviewsCount);
 
   // Find the parent container of the elements
-  const parentContainer = elements[0].closest('div[aria-label]').parentNode;
+  const parentContainer = elements[0].closest('div[aria-label]').parentNode.parentNode;
 
   // Reorder the elements in the UI
   sortedElements.forEach(({ element }) => {
-    const articleElement = element.closest('div[aria-label]');
+    const articleElement = element.closest('div[aria-label]').parentNode;
     parentContainer.appendChild(articleElement);
   });
 
-  document.querySelector('[aria-label="Results for Restaurants"]').firstChild.scrollIntoView();
+  document.querySelector('[role=feed]').firstChild.scrollIntoView();
 }
 
 function injectCSS(css) {


### PR DESCRIPTION
Based on a review I saw on chrome web store, I changed the logic to make sure that after sorting, results can be clicked individually.
<img width="600" alt="image" src="https://github.com/ranrib/google-maps-sorter/assets/3543224/14bf7ce0-d9a0-4f02-bed2-9e08e486c643">

I also adapted the scroll-to-top function so it works for things other than restaurants.

Thanks for your work building this extension!